### PR TITLE
update API calls for mk_export and PDB

### DIFF
--- a/EC_class_ligands_search.ipynb
+++ b/EC_class_ligands_search.ipynb
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "7f7f7135",
    "metadata": {},
    "outputs": [],
@@ -220,7 +220,7 @@
    "source": [
     "# Download one of the files from our list: 11U.mol2\n",
     "\n",
-    "res11U_mol2 = requests.get('https://files.rcsb.org/ligands/download/11U_ideal.mol2')"
+    "res11U_sdf = requests.get('https://files.rcsb.org/ligands/download/11U_ideal.sdf')"
    ]
   },
   {
@@ -232,7 +232,7 @@
    "source": [
     "# check to see that the file downloaded properly. A status code of 200 means everything is okay.\n",
     "\n",
-    "res11U_mol2"
+    "res11U_sdf"
    ]
   },
   {
@@ -247,8 +247,8 @@
     "# make a ligands folder for our results\n",
     "os.makedirs(\"\", exist_ok=True)\n",
     "\n",
-    "with open(\"ligands/res11U.mol2\", \"w+\") as file:\n",
-    "    file.write(res11U_mol2.text)"
+    "with open(\"ligands/res11U.sdf\", \"w+\") as file:\n",
+    "    file.write(res11U_sdf.text)"
    ]
   },
   {
@@ -261,7 +261,7 @@
     "# Now we use these commands to read the file and make sure it downloaded properly. As an alternative, we\n",
     "# could go to the ligands folder in our Jupyter desktop and click on res11U.mol2 to make sure it looks correct.\n",
     "\n",
-    "file1 = open('ligands/res11U.mol2', 'r')\n",
+    "file1 = open('ligands/res11U.sdf', 'r')\n",
     "file_text = file1.read() # This reads in the file as a string.\n",
     "\n",
     "print()"
@@ -297,7 +297,7 @@
     "baseUrl = \"https://files.rcsb.org/ligands/download/\"\n",
     "\n",
     "for ChemID in molResultL:\n",
-    "    cFile = f\"{ChemID}_ideal.mol2\"\n",
+    "    cFile = f\"{ChemID}_ideal.sdf\"\n",
     "    cFileUrl = baseUrl + cFile\n",
     "    cFileLocal = \"ligands/\" + cFile\n",
     "    response = requests.get(cFileUrl)\n",
@@ -340,7 +340,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },

--- a/docking_single_ligand.ipynb
+++ b/docking_single_ligand.ipynb
@@ -321,7 +321,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! mk_export.py docking_results/13U.pdbqt -o docking_results/13U.sdf"
+    "! mk_export.py docking_results/13U.pdbqt -s docking_results/13U.sdf # In the original workshop, `mk_export.py` used the option `-o` instead of `-s`. This was changed to `-s` in late 2024."
    ]
   },
   {

--- a/filled_notebooks/EC_class_ligands_search_pc.ipynb
+++ b/filled_notebooks/EC_class_ligands_search_pc.ipynb
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "7f7f7135",
    "metadata": {},
    "outputs": [],
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "ffb3d082",
    "metadata": {},
    "outputs": [],
@@ -212,14 +212,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "9cbf3513",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Download one of the files from our list: 11U.mol2\n",
+    "# Download one of the files from our list: 11U.sdf\n",
     "\n",
-    "res11U_mol2 = requests.get('https://files.rcsb.org/ligands/download/11U_ideal.mol2')"
+    "res11U_sdf = requests.get('https://files.rcsb.org/ligands/download/11U_ideal.sdf')"
    ]
   },
   {
@@ -231,12 +231,12 @@
    "source": [
     "# check to see that the file downloaded properly. A status code of 200 means everything is okay.\n",
     "\n",
-    "res11U_mol2.status_code"
+    "res11U_sdf.status_code"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "096a56da",
    "metadata": {},
    "outputs": [],
@@ -246,8 +246,8 @@
     "# make a ligands folder for our results\n",
     "os.makedirs(\"ligands\", exist_ok=True)\n",
     "\n",
-    "with open(\"ligands/res11U.mol2\", \"w+\") as file:\n",
-    "    file.write(res11U_mol2.text)"
+    "with open(\"ligands/res11U.sdf\", \"w+\") as file:\n",
+    "    file.write(res11U_sdf.text)"
    ]
   },
   {
@@ -260,7 +260,7 @@
     "# Now we use these commands to read the file and make sure it downloaded properly. As an alternative, we\n",
     "# could go to the ligands folder in our Jupyter desktop and click on res11U.mol2 to make sure it looks correct.\n",
     "\n",
-    "file1 = open('ligands/res11U.mol2', 'r')\n",
+    "file1 = open('ligands/res11U.sdf', 'r')\n",
     "file_text = file1.read() # This reads in the file as a string.\n",
     "\n",
     "print(file_text)"
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "b85d927b",
    "metadata": {},
    "outputs": [],
@@ -296,7 +296,7 @@
     "baseUrl = \"https://files.rcsb.org/ligands/download/\"\n",
     "\n",
     "for ChemID in molResultL:\n",
-    "    cFile = f\"{ChemID}_ideal.mol2\"\n",
+    "    cFile = f\"{ChemID}_ideal.sdf\"\n",
     "    cFileUrl = baseUrl + cFile\n",
     "    cFileLocal = \"ligands/\" + cFile\n",
     "    response = requests.get(cFileUrl)\n",
@@ -363,7 +363,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },

--- a/filled_notebooks/docking_prepration.ipynb
+++ b/filled_notebooks/docking_prepration.ipynb
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +453,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },

--- a/filled_notebooks/docking_single_ligand.ipynb
+++ b/filled_notebooks/docking_single_ligand.ipynb
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +313,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! mk_export.py docking_results/13U.pdbqt -o docking_results/13U.sdf"
+    "! mk_export.py docking_results/13U.pdbqt -s docking_results/13U.sdf # In the original workshop, `mk_export.py` used the option `-o` instead of `-s`. This was changed to `-s` in late 2024."
    ]
   },
   {
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,7 +454,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },

--- a/filled_notebooks/molecule_manipulation.ipynb
+++ b/filled_notebooks/molecule_manipulation.ipynb
@@ -63,7 +63,7 @@
     "IPythonConsole.drawOptions.addAtomIndices = True  # Show atom indices\n",
     "IPythonConsole.molSize = 600,600 # Set size of image\n",
     "\n",
-    "ligand = Chem.MolFromMol2File(\"ligands/13U_ideal.mol2\")\n",
+    "ligand = Chem.MolFromMolFile(\"ligands/13U_ideal.sdf\")\n",
     "ligand"
    ]
   },
@@ -89,7 +89,7 @@
    "outputs": [],
    "source": [
     "# load a duplicate copy of 13U to manipulate\n",
-    "mod_ligand_N = Chem.MolFromMol2File(\"ligands/13U_ideal.mol2\")\n",
+    "mod_ligand_N = Chem.MolFromMolFile(\"ligands/13U_ideal.sdf\")\n",
     "\n",
     "# change carbon in ring to a nitrogen\n",
     "mod_ligand_N.GetAtomWithIdx(23).SetAtomicNum(7)\n",
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +143,7 @@
    "source": [
     "# load another duplicate of the original ligand, but keep the hydrogens\n",
     "\n",
-    "mod_ligand_methyl = Chem.MolFromMol2File(\"ligands/13U_ideal.mol2\", removeHs=False)\n",
+    "mod_ligand_methyl = Chem.MolFromMolFile(\"ligands/13U_ideal.sdf\", removeHs=False)\n",
     "mod_ligand_methyl        # This is the original structure. In the cells below, we will convert Hydrogen-59 to a Carbon."
    ]
   },
@@ -179,7 +179,9 @@
     "# Optimize new molecules and save\n",
     "from rdkit.Chem import AllChem\n",
     "\n",
+    "Chem.SanitizeMol(mod_ligand_N)\n",
     "mod_ligand_NH = Chem.AddHs(mod_ligand_N)\n",
+    "\n",
     "\n",
     "# Do a constrained embedding to keep the ligand in the same position\n",
     "# this allows for the hydrogens to be added in reasonable locations, but keeps\n",
@@ -208,6 +210,7 @@
    "source": [
     "# Repeat process on methyl ligand\n",
     "\n",
+    "Chem.SanitizeMol(mod_ligand_methyl)\n",
     "mod_ligand_methylH = Chem.AddHs(mod_ligand_methyl)\n",
     "\n",
     "constrained_mol = AllChem.ConstrainedEmbed(mod_ligand_methylH, mod_ligand_methyl, useTethers=True)\n",
@@ -236,7 +239,7 @@
     "# make modified ligand directory\n",
     "os.makedirs(\"ligands_to_dock\", exist_ok=True)\n",
     "\n",
-    "ligand_H = Chem.MolFromMol2File(\"ligands/13U_ideal.mol2\", removeHs=False)\n",
+    "ligand_H = Chem.MolFromMolFile(\"ligands/13U_ideal.sdf\", removeHs=False)\n",
     "\n",
     "# save modified ligands sdf file - make sure all contain hydrogens and place \n",
     "# in a folder of ligands to dock.\n",
@@ -269,7 +272,7 @@
    "source": [
     "# Solution using ligand 32U\n",
     "\n",
-    "ligand = Chem.MolFromMol2File(\"ligands/32U_ideal.mol2\")\n",
+    "ligand = Chem.MolFromMolFile(\"ligands/32U_ideal.sdf\")\n",
     "ligand"
    ]
   },
@@ -279,7 +282,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mod_ligand_OH = Chem.MolFromMol2File(\"ligands/13U_ideal.mol2\", removeHs=False)\n",
+    "mod_ligand_OH = Chem.MolFromMolFile(\"ligands/13U_ideal.sdf\", removeHs=False)\n",
     "mod_ligand_OH        # This is the original structure. In the cells below, we will convert Hydrogen-59 to a Carbon."
    ]
   },
@@ -311,7 +314,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },

--- a/molecule_manipulation.ipynb
+++ b/molecule_manipulation.ipynb
@@ -61,7 +61,7 @@
     "IPythonConsole.drawOptions.addAtomIndices = True  # Show atom indices\n",
     "IPythonConsole.molSize = 600,600 # Set size of image\n",
     "\n",
-    "ligand = Chem.MolFromMol2File(\"ligands/13U_ideal.mol2\")\n",
+    "ligand = Chem.MolFromMolFile(\"ligands/13U_ideal.sdf\")\n",
     "ligand"
    ]
   },
@@ -87,7 +87,7 @@
    "outputs": [],
    "source": [
     "# load a duplicate copy of 13U to manipulate\n",
-    "mod_ligand_N = Chem.MolFromMol2File(\"ligands/13U_ideal.mol2\")\n",
+    "mod_ligand_N = Chem.MolFromMolFile(\"ligands/13U_ideal.sdf\")\n",
     "\n",
     "# change carbon in ring to a nitrogen\n",
     "mod_ligand_N.GetAtomWithIdx(23).SetAtomicNum()\n",
@@ -141,7 +141,7 @@
    "source": [
     "# load another duplicate of the original ligand, but keep the hydrogens\n",
     "\n",
-    "mod_ligand_methyl = Chem.MolFromMol2File(\"ligands/13U_ideal.mol2\", )\n",
+    "mod_ligand_methyl = Chem.MolFromMolFile(\"ligands/13U_ideal.sdf\", )\n",
     "mod_ligand_methyl        # This is the original structure. In the cells below, we will convert Hydrogen-59 to a Carbon."
    ]
   },
@@ -177,6 +177,7 @@
     "# Optimize new molecules and save\n",
     "from rdkit.Chem import\n",
     "\n",
+    "Chem.SanitizeMol(mod_ligand_N)\n",
     "mod_ligand_NH = Chem.AddHs(mod_ligand_N)\n",
     "\n",
     "# Do a constrained embedding to keep the ligand in the same position\n",
@@ -206,6 +207,7 @@
    "source": [
     "# Repeat process on methyl ligand\n",
     "\n",
+    "Chem.SanitizeMol(mod_ligand_methyl)\n",
     "mod_ligand_methylH = Chem.AddHs(mod_ligand_methyl)\n",
     "\n",
     "constrained_mol = AllChem.ConstrainedEmbed(mod_ligand_methylH, mod_ligand_methyl, useTethers=True)\n",
@@ -234,7 +236,7 @@
     "# make modified ligand directory\n",
     "os.makedirs(\"ligands_to_dock\", exist_ok=True)\n",
     "\n",
-    " = Chem.MolFromMol2File(\"ligands/13U_ideal.mol2\", removeHs=False)\n",
+    " = Chem.MolFromMolFile(\"ligands/13U_ideal.sdf\", removeHs=False)\n",
     "\n",
     "# save modified ligands sdf file - make sure all contain hydrogens and place \n",
     "# in a folder of ligands to dock.\n",


### PR DESCRIPTION
This PR addresses #3 - it updates the mol2 files from the PDB to sdf (mol2 no longer supported). It also updates use of `mk_export` to use `-s` option instead of `-o`.